### PR TITLE
Feature/SAAS-2987-reconnect-when-connection-is-closed

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Message Bus Abstraction with rabbitmq implementation
 
     func main() {        
         // Create msgbuzz instance
-        msgBus := msgbuzz.NewRabbitMqClient("amqp://127.0.0.1:5672", 4)
+        msgBus := msgbuzz.NewRabbitMqClient("amqp://127.0.0.1:5672", 4, 0)
     
         // Register consumer of some topic
         msgBus.On("profile.created", "reco_engine", func(confirm msgbuzz.MessageConfirm, bytes []byte) error {

--- a/examples/pubsub/main.go
+++ b/examples/pubsub/main.go
@@ -8,7 +8,7 @@ import (
 
 func main() {
 	// Create msgbuzz instance
-	msgBus := msgbuzz.NewRabbitMqClient("amqp://127.0.0.1:5672", 4)
+	msgBus := msgbuzz.NewRabbitMqClient("amqp://127.0.0.1:5672", 4, 0)
 
 	// Register consumer of some topic
 	msgBus.On("profile.created", "reco_engine", func(confirm msgbuzz.MessageConfirm, bytes []byte) error {

--- a/rabbitmq.go
+++ b/rabbitmq.go
@@ -1,27 +1,34 @@
 package msgbuzz
 
 import (
+	"errors"
 	"fmt"
-	"github.com/sirupsen/logrus"
-	"github.com/streadway/amqp"
 	"reflect"
 	"strconv"
 	"sync"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/streadway/amqp"
 )
 
 // RabbitMqClient RabbitMq implementation of MessageBus
 type RabbitMqClient struct {
-	conn        *amqp.Connection
-	consumerWg  sync.WaitGroup
-	subscribers []subscriber
-	threadNum   int
+	conn         *amqp.Connection
+	url          string
+	consumerWg   sync.WaitGroup
+	subscribers  []subscriber
+	threadNum    int
+	maxRcAttempt int
 }
 
-func NewRabbitMqClient(conn string, threadNum int) *RabbitMqClient {
+func NewRabbitMqClient(conn string, threadNum int, maxReconnectAttempt int) *RabbitMqClient {
 	mc := &RabbitMqClient{
-		threadNum: threadNum,
+		url:          conn,
+		threadNum:    threadNum,
+		maxRcAttempt: maxReconnectAttempt,
 	}
-	mc.connectToBroker(conn)
+	mc.connectToBroker()
 	return mc
 }
 
@@ -88,6 +95,22 @@ func (m *RabbitMqClient) Close() error {
 }
 
 func (m *RabbitMqClient) StartConsuming() error {
+	if err := m.startConsumingSubscribers(); err != nil {
+		return err
+	}
+
+	if m.maxRcAttempt > 1 {
+		logrus.Info("Adding WaitGroup due to reconnect possibility")
+		m.consumerWg.Add(1)
+	}
+
+	m.consumerWg.Wait()
+
+	return nil
+}
+
+func (m *RabbitMqClient) startConsumingSubscribers() error {
+	logrus.Info("Start consuming subscribers")
 	for _, sub := range m.subscribers {
 		for i := 0; i < m.threadNum; i++ {
 			err := m.consume(sub.topicName, sub.consumerName, sub.messageHandler)
@@ -96,8 +119,6 @@ func (m *RabbitMqClient) StartConsuming() error {
 			}
 		}
 	}
-
-	m.consumerWg.Wait()
 
 	return nil
 }
@@ -161,16 +182,63 @@ type subscriber struct {
 	messageHandler MessageHandler
 }
 
-func (m *RabbitMqClient) connectToBroker(connectionString string) {
-	if connectionString == "" {
-		panic("Cannot initialize connection to broker, connectionString not set. Have you initialized?")
+func (m *RabbitMqClient) connectToBroker() error {
+	if m.url == "" {
+		return errors.New("cannot initialize connection to broker, connectionString not set. Have you initialized?")
 	}
 
 	var err error
-	m.conn, err = amqp.Dial(fmt.Sprintf("%s/", connectionString))
+	m.conn, err = amqp.Dial(fmt.Sprintf("%s/", m.url))
 	if err != nil {
-		panic("Failed to connect to AMQP compatible broker at: " + connectionString + err.Error())
+		return errors.New("Failed to connect to AMQP compatible broker at: " + m.url + err.Error())
 	}
+
+	// spin notify close listener
+	if m.maxRcAttempt > 0 {
+		go func() {
+			logrus.Info("Starting notify close listener")
+			notifyCloseErr := <-m.conn.NotifyClose(make(chan *amqp.Error))
+			logrus.WithError(notifyCloseErr).Info("Connection is closed: Attempting to reconnect")
+			if err := m.reconnect(); err != nil {
+				panic(err)
+			}
+		}()
+	}
+
+	return nil
+}
+
+func (m *RabbitMqClient) reconnect() error {
+	logger := logrus.WithField("method", "reconnect").WithField("url", m.url)
+	logger.Infof("About to start reconnecting into %s", m.url)
+
+	// TODO: Make step configurable.
+	step := 10 * time.Second
+
+	for i := 1; i <= m.maxRcAttempt; i++ {
+		logger.Infof("Attempting to reconnect [%d/%d]", i, m.maxRcAttempt)
+
+		// Sleep between attempts of reconnecting to avoid consecutive errors
+		if i > 1 {
+			time.Sleep(time.Duration(i-1) * step)
+		}
+
+		if err := m.connectToBroker(); err != nil {
+			logger.WithError(err).Warning("Error when connecting to broker")
+			continue
+		}
+
+		if err := m.startConsumingSubscribers(); err != nil {
+			logger.WithError(err).Warning("Error when starting to consume subscribers")
+			continue
+		}
+
+		logger.Infof("Succesfully reconnect after %d attempts", i)
+
+		return nil
+	}
+
+	return errors.New("maximum number of reconnect is reached")
 }
 
 func consumeLoop(wg *sync.WaitGroup, channel *amqp.Channel, deliveries <-chan amqp.Delivery, handlerFunc MessageHandler, names *QueueNameGenerator) {

--- a/rabbitmq_msgconfirm_test.go
+++ b/rabbitmq_msgconfirm_test.go
@@ -12,7 +12,7 @@ import (
 
 // TODO improve testing
 func TestRabbitMqMessageConfirm_TotalFailed(t *testing.T) {
-	mc := msgbuzz.NewRabbitMqClient(os.Getenv("RABBITMQ_URL"), 1)
+	mc := msgbuzz.NewRabbitMqClient(os.Getenv("RABBITMQ_URL"), 1, 0)
 	topicName := "msgconfirm_total_failed_test"
 	consumerName := "msgconfirm_test"
 


### PR DESCRIPTION
Hi, this is Rafi.

This PR will add reconnect mechanism when connection is closed

Jira:
[SAAS-2987](https://shortlyst.atlassian.net/browse/SAAS-2987)

Changes:
- Add `maxReconnectAttempt` as an arg when initiating MsgBuzz client
- Spin up go routine when dialing connection to listen for connection close event

Currently, I am still figuring out what unit/integration tests that this feature need. What I've done relating to testing, in steps, are:

1. Connect to RabbitMQ server
2. Send messages to corresponding Queue
3. Disconnect go-msgbuzz client from RabbitMQ

And the results are:

- go-msgbuzz able to get reconnected
- Messages are received on the consumer after get reconnected

Thank you.

Any feedbacks are welcome.

References:
- [Automatically recovering RabbitMQ connections in Go app](https://medium.com/@dhanushgopinath/automatically-recovering-rabbitmq-connections-in-go-applications-7795a605ca59)
- [Docs about amqp.Channel.NotifyClose](https://pkg.go.dev/github.com/streadway/amqp#Channel.NotifyClose)

p.s. I don't know what is Bob's and Ryan's github account, so maybe we can mention to them later about this PR. Thank you.